### PR TITLE
修复getFileSizeByPath方法传入非文件夹路径时返回大小为0的bug

### DIFF
--- a/EUExFileMgr/EUExFileMgr/EUExFileMgr.m
+++ b/EUExFileMgr/EUExFileMgr/EUExFileMgr.m
@@ -466,6 +466,14 @@
     if (![manager fileExistsAtPath:folderPath]){
         return -1;
     }
+    
+    NSEnumerator *childFilesEnumerator = [[manager subpathsAtPath:folderPath] objectEnumerator];
+    if ([childFilesEnumerator nextObject] == nil) {
+        long long oneFolderSize = [[manager attributesOfItemAtPath:folderPath error:nil] fileSize];
+        //NSLog(@"appcan-->EUExFileMgr-->获取路径文件夹内文件大小 folderSizeAtPath-->没有子文件 return folderSize = %lld,dic = %@",oneFolderSize,[manager attributesOfItemAtPath:folderPath error:nil]);
+        return (CGFloat)oneFolderSize;
+    }
+    
     NSArray<NSString *> *subpaths = [manager subpathsAtPath:folderPath];
     __block CGFloat folderSize = 0;
     [subpaths enumerateObjectsUsingBlock:^(NSString * _Nonnull fileName, NSUInteger idx, BOOL * _Nonnull stop) {

--- a/EUExFileMgr/uexFileMgr/info.xml
+++ b/EUExFileMgr/uexFileMgr/info.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <uexplugins>
     <plugin
-        uexName="uexFileMgr" version="4.0.3" build="3">
-        <info>3:修正部分cb旧接口的参数问题</info>
+        uexName="uexFileMgr" version="4.0.4" build="4">
+        <info>4:修复getFileSizeByPath方法传入非文件夹路径时返回大小为0的bug</info>
+        <build>3:修正部分cb旧接口的参数问题</build>
         <build>2:兼容性更新</build>
         <build>1:新增getFileHashValue接口</build>
         <build>0:文件管理插件</build>


### PR DESCRIPTION
修复getFileSizeByPath方法传入非文件夹路径时返回大小为0的bug